### PR TITLE
Move language color resources.

### DIFF
--- a/feature/home/src/main/res/values/colors.xml
+++ b/feature/home/src/main/res/values/colors.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Programing language colors-->
+    <color name="kotlin">#4caf50</color>
+    <color name="cpp">#3f51b5</color>
+    <color name="dart">#03a9f4</color>
+    <color name="python">#ffc107</color>
+    <color name="java">#f44336</color>
+    <color name="html">#ff5722</color>
+    <color name="other">#607d8b</color>
+</resources>

--- a/viewCommon/src/main/res/values/colors.xml
+++ b/viewCommon/src/main/res/values/colors.xml
@@ -3,12 +3,4 @@
     <color name="white">#fff</color>
     <color name="text">#222</color>
     <color name="textGray">#666</color>
-    <!-- Programing language colors-->
-    <color name="kotlin">#4caf50</color>
-    <color name="cpp">#3f51b5</color>
-    <color name="dart">#03a9f4</color>
-    <color name="python">#ffc107</color>
-    <color name="java">#f44336</color>
-    <color name="html">#ff5722</color>
-    <color name="other">#607d8b</color>
 </resources>


### PR DESCRIPTION
close #44

# Changes

Move language color resources from `viewCommon` module to `feature:home` module.
