### PR TITLE
checkout action uses fetch-depth option.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,8 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: main
-      - uses: actions/checkout@v2
+          fetch-depth: 0
       - uses: actions/setup-java@v1
         with:
           java-version: '11'


### PR DESCRIPTION
# Changes

- `checkout` action uses `fetch-depth` option.

## Reason

Sometime Danger fail.