### PR TITLE
Migration to kotlinx-coroutines-test 1.6.1 API

### DIFF
--- a/feature/home/presentation/src/test/java/com/tfandkusu/template/viewmodel/home/HomeViewModelTest.kt
+++ b/feature/home/presentation/src/test/java/com/tfandkusu/template/viewmodel/home/HomeViewModelTest.kt
@@ -16,9 +16,9 @@ import io.mockk.verifySequence
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
@@ -32,7 +32,7 @@ class HomeViewModelTest {
     val rule: TestRule = InstantTaskExecutorRule()
 
     @ExperimentalCoroutinesApi
-    private val testDispatcher = TestCoroutineDispatcher()
+    private val testDispatcher = UnconfinedTestDispatcher()
 
     @MockK(relaxed = true)
     private lateinit var loadUseCase: HomeLoadUseCase
@@ -54,12 +54,11 @@ class HomeViewModelTest {
     @After
     fun tearDown() {
         Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
     }
 
     @ExperimentalCoroutinesApi
     @Test
-    fun onCreate() = testDispatcher.runBlockingTest {
+    fun onCreate() = runTest {
         val repos = GitHubRepoCatalog.getList()
         every {
             onCreateUseCase.execute()
@@ -79,7 +78,7 @@ class HomeViewModelTest {
 
     @ExperimentalCoroutinesApi
     @Test
-    fun loadSuccess() = testDispatcher.runBlockingTest {
+    fun loadSuccess() = runTest {
         val stateMockObserver = viewModel.state.mockStateObserver()
         val errorStateMockObserver = viewModel.error.state.mockStateObserver()
         viewModel.event(HomeEvent.Load)
@@ -95,7 +94,7 @@ class HomeViewModelTest {
 
     @ExperimentalCoroutinesApi
     @Test
-    fun loadError() = testDispatcher.runBlockingTest {
+    fun loadError() = runTest {
         coEvery {
             loadUseCase.execute()
         } throws NetworkErrorException()

--- a/feature/info/presentation/src/test/java/com/tfandkusu/template/viewmodel/info/InfoViewModelTest.kt
+++ b/feature/info/presentation/src/test/java/com/tfandkusu/template/viewmodel/info/InfoViewModelTest.kt
@@ -10,9 +10,9 @@ import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
@@ -26,7 +26,7 @@ class InfoViewModelTest {
     val rule: TestRule = InstantTaskExecutorRule()
 
     @ExperimentalCoroutinesApi
-    private val testDispatcher = TestCoroutineDispatcher()
+    private val testDispatcher = UnconfinedTestDispatcher()
 
     @MockK(relaxed = true)
     private lateinit var onClickAboutUseCase: InfoOnClickAboutUseCase
@@ -45,12 +45,11 @@ class InfoViewModelTest {
     @After
     fun tearDown() {
         Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
     }
 
     @Test
     @ExperimentalCoroutinesApi
-    fun onClickAbout() = testDispatcher.runBlockingTest {
+    fun onClickAbout() = runTest {
         every {
             onClickAboutUseCase.execute()
         } returns InfoOnClickAboutUseCaseResult(3)


### PR DESCRIPTION
close issue_number

# Changes

Migration to kotlinx-coroutines-test 1.6.1 API

- Use `UnconfinedTestDispatcher` from `TestCoroutineDispatcher`
- Use `runTest` from `testDispatcher.runBlockingTest`

# Note

[Migration to the new kotlinx-coroutines-test API](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-test/MIGRATION.md)
