### PR TITLE
Update moshi to 1.13

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -32,7 +32,6 @@
             <option value="$PROJECT_DIR$/viewCommon" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/data/remote/build.gradle
+++ b/data/remote/build.gradle
@@ -1,11 +1,16 @@
-apply plugin: 'com.android.library'
+plugins {
+    id("com.android.library")
+    id("com.google.devtools.ksp").version("1.6.10-1.0.4")
+}
 apply from: rootProject.file("gradle/common.gradle")
 apply from: rootProject.file("gradle/hilt.gradle")
 
 dependencies {
+    ksp libs.moshi.kotlin.codegen
     implementation project(':common:model')
     implementation project(':common:util')
     implementation libs.retrofit.retrofit
     implementation libs.retrofit.moshi
+    implementation libs.moshi
     implementation libs.moshi.adapter
 }

--- a/data/remote/src/main/java/com/tfandkusu/template/api/response/GithubRepoListResponseItem.kt
+++ b/data/remote/src/main/java/com/tfandkusu/template/api/response/GithubRepoListResponseItem.kt
@@ -1,10 +1,10 @@
 package com.tfandkusu.template.api.response
 
-import androidx.annotation.Keep
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.util.Date
 
-@Keep
+@JsonClass(generateAdapter = true)
 data class GithubRepoListResponseItem(
     val id: Long,
     val name: String,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ room = '2.4.2'
 coroutines = '1.6.1'
 lifecycle = '2.4.1'
 hilt = '2.42'
+moshi = '1.13.0'
 
 [libraries]
 # Gradle Plugin
@@ -34,7 +35,9 @@ play-services-oss-licenses = 'com.google.android.gms:play-services-oss-licenses:
 # Retrofit
 retrofit-retrofit = { module = 'com.squareup.retrofit2:retrofit', version.ref = 'retrofit' }
 retrofit-moshi = { module = 'com.squareup.retrofit2:converter-moshi', version.ref = 'retrofit' }
-moshi-adapter = 'com.squareup.moshi:moshi-adapters:1.8.0'
+moshi = { module = 'com.squareup.moshi:moshi', version.ref = 'moshi' }
+moshi-adapter = { module = 'com.squareup.moshi:moshi-adapters', version.ref = 'moshi' }
+moshi-kotlin-codegen = { module = 'com.squareup.moshi:moshi-kotlin-codegen', version.ref = 'moshi' }
 # Room
 room-runtime = { module = 'androidx.room:room-runtime', version.ref = 'room' }
 room-ktx = { module = 'androidx.room:room-ktx', version.ref = 'room' }


### PR DESCRIPTION
# Changes

- Update moshi to 1.13
- `GithubRepoListResponseItem ` does not use `@Keep` annotation
