### PR TITLE
Add Dependency Tree Diff to check workflow.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,6 +33,28 @@ jobs:
       - run: curl -Os https://uploader.codecov.io/latest/linux/codecov
       - run: chmod +x codecov
       - run: ./codecov -t ${{ secrets.CODECOV_TOKEN }}
+      # Dependency Tree Diff
+      - id: dependency-diff
+        name: Generate dependency diff
+        uses: usefulness/dependency-tree-diff-action@v1
+      - uses: peter-evans/find-comment@v1
+        id: find_comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: Dependency diff
+
+      - uses: peter-evans/create-or-update-comment@v1
+        if: ${{ steps.dependency-diff.outputs.text-diff != null || steps.find_comment.outputs.comment-id != null }}
+        with:
+          body: |
+            Dependency diff (customize your message here):
+              ```diff
+              ${{ steps.dependency-diff.outputs.text-diff }}
+              ```
+          edit-mode: replace
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       # Slack
       - uses: tfandkusu/slack@v1
         env:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ compose-ui-ui = { module = 'androidx.compose.ui:ui', version.ref = 'compose' }
 compose-material = { module = 'androidx.compose.material:material', version.ref = 'compose' }
 compose-ui-preview = { module = 'androidx.compose.ui:ui-tooling-preview', version.ref = 'compose' }
 compose-ui-tooling = { module = 'androidx.compose.ui:ui-tooling', version.ref = 'compose' }
-navigation-compose = 'androidx.navigation:navigation-compose:2.5.0'
+navigation-compose = 'androidx.navigation:navigation-compose:2.5.1'
 activity-compose = 'androidx.activity:activity-compose:1.5.0'
 compose-livedata = { module = 'androidx.compose.runtime:runtime-livedata', version.ref='compose' }
 preference = 'androidx.preference:preference-ktx:1.2.0'


### PR DESCRIPTION
- [Add Dependency Tree Diff](https://github.com/marketplace/actions/dependency-tree-diff-for-gradle) to check workflow
- Update Navigation Compose to 1.5.1