### PR TITLE
Make RunWhenLaunched composable function.

### DIFF
--- a/feature/home/compose/src/main/java/com/tfandkusu/template/compose/home/HomeScreen.kt
+++ b/feature/home/compose/src/main/java/com/tfandkusu/template/compose/home/HomeScreen.kt
@@ -28,6 +28,7 @@ import com.tfandkusu.template.compose.home.listitem.GitHubRepoListItem
 import com.tfandkusu.template.home.compose.R
 import com.tfandkusu.template.ui.theme.MyAppTheme
 import com.tfandkusu.template.view.error.ApiError
+import com.tfandkusu.template.view.error.RunWhenLaunched
 import com.tfandkusu.template.viewmodel.error.ApiErrorViewModelHelper
 import com.tfandkusu.template.viewmodel.error.useErrorState
 import com.tfandkusu.template.viewmodel.home.HomeEffect
@@ -45,8 +46,10 @@ private const val CONTENT_TYPE_REPO = 1
 @Composable
 fun HomeScreen(viewModel: HomeViewModel, callInfoScreen: () -> Unit = {}) {
     val (state, _, dispatch) = use(viewModel)
-    LaunchedEffect(Unit) {
+    RunWhenLaunched {
         dispatch(HomeEvent.OnCreate)
+    }
+    LaunchedEffect(Unit) {
         dispatch(HomeEvent.Load)
     }
     val errorState = useErrorState(viewModel.error)

--- a/feature/home/presentation/src/main/java/com/tfandkusu/template/viewmodel/home/HomeViewModelImpl.kt
+++ b/feature/home/presentation/src/main/java/com/tfandkusu/template/viewmodel/home/HomeViewModelImpl.kt
@@ -37,8 +37,6 @@ class HomeViewModelImpl @Inject constructor(
 
     override val effect: Flow<HomeEffect> = effectChannel.receiveAsFlow()
 
-    private var once = false
-
     override fun event(event: HomeEvent) {
         viewModelScope.launch {
             when (event) {
@@ -58,19 +56,15 @@ class HomeViewModelImpl @Inject constructor(
                     }
                 }
                 HomeEvent.OnCreate -> {
-                    // Prevent multiple execution of collect blocks
-                    if (!once) {
-                        once = true
-                        onCreateUseCase.execute().collect { repos ->
-                            _state.update {
-                                copy(
-                                    items = repos.map {
-                                        HomeStateItem(
-                                            it
-                                        )
-                                    }
-                                )
-                            }
+                    onCreateUseCase.execute().collect { repos ->
+                        _state.update {
+                            copy(
+                                items = repos.map {
+                                    HomeStateItem(
+                                        it
+                                    )
+                                }
+                            )
                         }
                     }
                 }

--- a/feature/home/presentation/src/test/java/com/tfandkusu/template/viewmodel/home/HomeViewModelTest.kt
+++ b/feature/home/presentation/src/test/java/com/tfandkusu/template/viewmodel/home/HomeViewModelTest.kt
@@ -54,8 +54,6 @@ class HomeViewModelTest {
         }
         val mockStateObserver = viewModel.state.mockStateObserver()
         viewModel.event(HomeEvent.OnCreate)
-        // Use usecase only once.
-        viewModel.event(HomeEvent.OnCreate)
         verifySequence {
             mockStateObserver.onChanged(HomeState())
             onCreateUseCase.execute()

--- a/viewCommon/src/main/java/com/tfandkusu/template/view/error/RunWhenLaunched.kt
+++ b/viewCommon/src/main/java/com/tfandkusu/template/view/error/RunWhenLaunched.kt
@@ -1,0 +1,21 @@
+package com.tfandkusu.template.view.error
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+
+@Composable
+fun RunWhenLaunched(black: () -> Unit) {
+    var launched by rememberSaveable {
+        mutableStateOf(true)
+    }
+    LaunchedEffect(Unit) {
+        if (launched) {
+            black()
+            launched = false
+        }
+    }
+}


### PR DESCRIPTION
# User story

- `HomeEvent.OnCreate` event  uses ` viewModelScope.launch` and `Flow#collect`.
- When user rotate screen, `LaunchedEffect(Unit)` rerun. But `Flow#collect` is not end. `Flow` is multiply observed.
- So I make `RunWhenLaunched`  composable function to run only when screen composable function launch.
