### PR TITLE
Developer can see dependency tree of libraries

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ moshi = '1.14.0'
 
 [libraries]
 # Gradle Plugin
-android-gradle = 'com.android.tools.build:gradle:7.4.0'
+android-gradle = 'com.android.tools.build:gradle:7.3.1'
 kotlin-gradle = { module = 'org.jetbrains.kotlin:kotlin-gradle-plugin', version.ref = 'kotlin' }
 spotless-gradle = 'com.diffplug.spotless:spotless-plugin-gradle:6.12.1'
 hilt-gradle = { module = 'com.google.dagger:hilt-android-gradle-plugin', version.ref = 'hilt' }


### PR DESCRIPTION
Developer see dependency tree using this command.

```sh
./gradlew app:dependencies
```

# Before

Gradle output this error.

```
FAILURE: Build failed with an exception.

* Where:
Build file '/Users/toya/work/android_app_template/common/build.gradle' line: 1

* What went wrong:
A problem occurred evaluating project ':common'.
> Failed to apply plugin 'com.android.internal.library'.
   > Accessing GradleBuildProject.Builder through AnalyticsConfiguratorService is not allowed after AnalyticsService is created.
```